### PR TITLE
Check and update version for transactional client

### DIFF
--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/transactional/TransactionalClient.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/transactional/TransactionalClient.java
@@ -79,6 +79,7 @@ public class TransactionalClient {
     }
 
     /**
+     * Node by given path should exist, value of given node will be overwritten.
      * Usage: invoke this method with the same parameter during different transactions,
      * which must not succeed in parallel.
      *

--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/transactional/TransactionalClient.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/transactional/TransactionalClient.java
@@ -78,6 +78,18 @@ public class TransactionalClient {
         return this;
     }
 
+    /**
+     * @param path node, which version should be checked and updated
+     * @return previous version of updating node
+     */
+    public int checkAndUpdateVersion(String path) throws Exception {
+        int version = curatorFramework.checkExists().forPath(path).getVersion();
+        checkPathWithVersion(path, version);
+        setData(path, new byte[]{});
+        return version;
+    }
+
+
     public static void tryCommit(CuratorFramework curatorFramework, int times, TransactionCreator transactionCreator)
             throws Exception {
         for (int i = 0; i < times; i++) {

--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/transactional/TransactionalClient.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/transactional/TransactionalClient.java
@@ -79,6 +79,9 @@ public class TransactionalClient {
     }
 
     /**
+     * Usage: invoke this method with the same parameter during different transactions,
+     * which must not succeed in parallel.
+     *
      * @param path node, which version should be checked and updated
      * @return previous version of updating node
      */


### PR DESCRIPTION
This is a common usage of TransactionalClient, when we want to sync separated servers by zookeeper. Let's make a method with a readable name