### PR TITLE
fix log level of zk printer exception

### DIFF
--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/utils/ZkTreePrinter.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/utils/ZkTreePrinter.java
@@ -34,16 +34,11 @@ public class ZkTreePrinter {
     }
 
     public String print(String path, boolean includeData) {
-        try {
-            StringBuilder out = new StringBuilder();
-            out.append("\n");
+        StringBuilder out = new StringBuilder();
+        out.append("\n");
 
-            print(path, out, 0, includeData);
-            return out.toString();
-        } catch (Exception e) {
-            log.warn(e.getMessage(), e);
-            return "";
-        }
+        print(path, out, 0, includeData);
+        return out.toString();
     }
 
     private void print(String path, StringBuilder out, int level, boolean includeData) {
@@ -53,7 +48,7 @@ public class ZkTreePrinter {
                 String data = includeData ? " " + new String(client.getData().forPath(ZKPaths.makePath(path, child))) : "";
                 out.append("└ ").append(child).append(data);
             } catch (Exception e) {
-                log.error("Error while trying print znode for path " + path, e);
+                log.debug("Error while trying print znode for path " + path, e);
             }
             out.append("\n");
 


### PR DESCRIPTION
Downgrade log level to debug because:
For example, we need to zk all zk path paths from zkRoot.
Steps.
1) Reed all children
**lock-1**
**lock-2**
2) For every child iteratively fetch data in this node.
3) At time when node **lock-1** was proccessed, LockManager released **lock-2** and there log error will be printed.

q: why hasn't this happened before?
a: because there is no ability to print data of node. DJM used custom ZkTreePrinter, which didn't have this feature