### PR TITLE
Feature/Fix release scheduler race condition

### DIFF
--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringDistributedLock.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringDistributedLock.java
@@ -313,6 +313,7 @@ public class PersistentExpiringDistributedLock implements AutoCloseable {
         assertNotClosed();
 
         Stat nodeStat = curatorFramework.checkExists().forPath(lockId.getNodePath());
+        if (nodeStat == null) return false;
         try {
             LockData lockData = decodeLockData(curatorFramework.getData().forPath(lockId.getNodePath()));
             if (!lockData.isOwnedBy(uuid)) {

--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
@@ -24,29 +24,17 @@ public class PersistentExpiringLockManager implements AutoCloseable {
     private final ActiveLocksContainer locksContainer;
     private final ReschedulableScheduler lockProlongationScheduler;
 
-    PersistentExpiringLockManager(
-            CuratorFramework curatorFramework,
-            DynamicProperty<PersistentExpiringLockManagerConfig> config,
-            ActiveLocksContainer activeLocksContainer,
-            ReschedulableScheduler lockProlongationScheduler
-    ) {
-        validateConfig(config.get());
-        this.curatorFramework = curatorFramework;
-        this.config = config;
-        this.locksContainer = activeLocksContainer;
-        this.lockProlongationScheduler = lockProlongationScheduler;
-    }
-
     public PersistentExpiringLockManager(
             CuratorFramework curatorFramework,
             DynamicProperty<PersistentExpiringLockManagerConfig> config,
             Profiler profiler
     ) {
-        this(
-                curatorFramework,
-                config,
-                new ActiveLocksContainer(),
-                NamedExecutors.newSingleThreadScheduler("PersistentExpiringLockManager", profiler)
+        validateConfig(config.get());
+        this.curatorFramework = curatorFramework;
+        this.config = config;
+        this.locksContainer = new ActiveLocksContainer();
+        this.lockProlongationScheduler = NamedExecutors.newSingleThreadScheduler(
+                "PersistentExpiringLockManager", profiler
         );
         lockProlongationScheduler.schedule(
                 Schedule.withDelay(config.map(prop -> prop.getLockCheckAndProlongInterval().toMillis())),

--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
@@ -1,5 +1,6 @@
 package ru.fix.zookeeper.lock;
 
+import kotlin.Unit;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,15 +10,8 @@ import ru.fix.stdlib.concurrency.threads.NamedExecutors;
 import ru.fix.stdlib.concurrency.threads.ReschedulableScheduler;
 import ru.fix.stdlib.concurrency.threads.Schedule;
 
-import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.BiFunction;
-
-import static ru.fix.zookeeper.lock.PersistentExpiringLockManager.ActiveLocksContainer.ProcessingLockResult.*;
 
 /**
  * Acquires {@code PersistentExpiringDistributedLock} locks and automatically prolongs them.
@@ -71,16 +65,21 @@ public class PersistentExpiringLockManager implements AutoCloseable {
                                 "Failed to checkAndProlongIfExpiresIn persistent locks with lockId {}", lockId, e
                         );
                     }
-                    return prolonged ? KEEP_LOCK_IN_CONTAINER : REMOVE_LOCK_FROM_CONTAINER;
+                    return prolonged
+                            ? ProcessingLockResult.KEEP_LOCK_IN_CONTAINER
+                            : ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER;
                 }, (lockId, listener, processingLockResult) -> {
-                    if (processingLockResult == REMOVE_LOCK_FROM_CONTAINER) {
+                    if (processingLockResult == ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER) {
                         logger.error("Failed lock prolongation for lock={}. Lock is removed from manager", lockId);
                         try {
                             listener.onLockProlongationFailedAndRemoved(lockId);
                         } catch (Exception exc) {
                             logger.error("Failed to invoke ProlongationFailedListener on lock {}", lockId, exc);
                         }
+                    } else {
+                        // nothing to do
                     }
+                    return Unit.INSTANCE;
                 })
         );
     }
@@ -133,7 +132,7 @@ public class PersistentExpiringLockManager implements AutoCloseable {
     }
 
     public Optional<PersistentExpiringDistributedLock.State> getLockState(LockIdentity lockId) throws Exception {
-        return locksContainer.getLockState(lockId);
+        return Optional.ofNullable(locksContainer.getLockState(lockId));
     }
 
     public void release(LockIdentity lockId) {
@@ -165,162 +164,10 @@ public class PersistentExpiringLockManager implements AutoCloseable {
             } catch (Exception e) {
                 logger.error("Failed to close lock with lockId={}", lockId, e);
             }
-            return REMOVE_LOCK_FROM_CONTAINER;
-        }, (lockId, lockListener, processingLockResult) -> {
-            // nothing to do
-        });
+            return ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER;
+        }, (lockId, lockListener, processingLockResult) -> Unit.INSTANCE);
         locksContainer.close();
         lockProlongationScheduler.close();
-    }
-
-    /**
-     * Contains the locks and provide synced access to remove, prolong and getState operations under locks
-     */
-    static class ActiveLocksContainer implements AutoCloseable {
-        /**
-         * remove, prolong and getState operations MUST BE synced under {@link #globalLock}
-         */
-        private final ConcurrentMap<LockIdentity, LockContainer> locks = new ConcurrentHashMap<>();
-
-        /**
-         * all operations with accessing to {@link #locks} has been synced with this object
-         * LockContainer is encapsulated inside this class so for performance issue this lock could be
-         * replaced with syncing via LockContainer
-         */
-        private final ReentrantLock globalLock = new ReentrantLock(true);
-
-        /**
-         * @return - old value in the map
-         */
-        @Nullable
-        public PersistentExpiringDistributedLock putLock(
-                LockIdentity lockId,
-                PersistentExpiringDistributedLock lock,
-                LockProlongationFailedListener listener
-        ) {
-            LockContainer newLockContainer = new LockContainer(lock, listener);
-            LockContainer oldLockContainer = locks.put(lockId, newLockContainer);
-            if (oldLockContainer != null) {
-                return oldLockContainer.lock;
-            } else {
-                return null;
-            }
-        }
-
-        @Nullable
-        public PersistentExpiringDistributedLock removeLock(LockIdentity lockId) {
-            try {
-                globalLock.lock();
-                return Optional.ofNullable(locks.remove(lockId))
-                        .map(lockContainer -> lockContainer.lock)
-                        .orElse(null);
-            } finally {
-                globalLock.unlock();
-            }
-        }
-
-        public boolean contains(LockIdentity lockId) {
-            return locks.containsKey(lockId);
-        }
-
-        public Optional<PersistentExpiringDistributedLock.State> getLockState(LockIdentity lockId) throws Exception {
-            try {
-                globalLock.lock();
-                LockContainer lockContainer = locks.get(lockId);
-                if (lockContainer != null) {
-                    return Optional.of(lockContainer.lock.getState());
-                } else {
-                    return Optional.empty();
-                }
-            } finally {
-                globalLock.unlock();
-            }
-        }
-
-        /**
-         * @param lockProcessor           - processor that returns what to do with Lock in collection
-         * @param lockResultPostProcessor - processor that does some work after processing and applied action
-         */
-        public void processAllLocks(
-                BiFunction<LockIdentity, PersistentExpiringDistributedLock, ProcessingLockResult> lockProcessor,
-                LockResultPostProcessor lockResultPostProcessor
-        ) {
-            locks.forEach((lockId, lockContainer) -> {
-                try {
-                    globalLock.lock();
-                    final ProcessingLockResult processingLockResult;
-                    if (locks.containsKey(lockId)) {
-                        processingLockResult = lockProcessor.apply(lockId, lockContainer.lock);
-                    } else {
-                        processingLockResult = ALREADY_REMOVED;
-                    }
-                    applyProcessingLockResult(lockId, processingLockResult);
-                    lockResultPostProcessor.apply(
-                            lockId, lockContainer.prolongationFailedListener, processingLockResult
-                    );
-                } finally {
-                    globalLock.unlock();
-                }
-            });
-        }
-
-        /**
-         * clear container without closing content in {@link #locks}
-         * should be closed on the upper level!
-         */
-        @Override
-        public void close() {
-            locks.clear();
-        }
-
-        private void applyProcessingLockResult(
-                LockIdentity lockId,
-                ProcessingLockResult processingLockResult
-        ) {
-            switch (processingLockResult) {
-                case REMOVE_LOCK_FROM_CONTAINER:
-                    locks.remove(lockId);
-                    break;
-                case KEEP_LOCK_IN_CONTAINER:
-                    // do nothing
-                    break;
-                case ALREADY_REMOVED:
-                    logger.trace("Lock with lockId {} already has been removed by other thread", lockId);
-                    break;
-                default:
-                    throw new IllegalStateException(
-                            "Unexpected value for processingLockResult " + processingLockResult
-                    );
-            }
-        }
-
-        private static class LockContainer {
-            public final PersistentExpiringDistributedLock lock;
-            public final LockProlongationFailedListener prolongationFailedListener;
-
-            public LockContainer(
-                    PersistentExpiringDistributedLock lock,
-                    LockProlongationFailedListener prolongationFailedListener
-            ) {
-                this.lock = lock;
-                this.prolongationFailedListener = prolongationFailedListener;
-            }
-        }
-
-        @FunctionalInterface
-        public interface LockResultPostProcessor {
-            void apply(
-                    LockIdentity lockId,
-                    LockProlongationFailedListener lockListener,
-                    ProcessingLockResult processingLockResult
-            );
-        }
-
-        enum ProcessingLockResult {
-            KEEP_LOCK_IN_CONTAINER,
-            REMOVE_LOCK_FROM_CONTAINER,
-            ALREADY_REMOVED
-        }
     }
 
 }

--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
@@ -265,7 +265,8 @@ public class PersistentExpiringLockManager implements AutoCloseable {
         }
 
         /**
-         *
+         * clear container without closing content in {@link #locks}
+         * should be closed on the upper level!
          */
         @Override
         public void close() {

--- a/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
+++ b/jfix-zookeeper/src/main/java/ru/fix/zookeeper/lock/PersistentExpiringLockManager.java
@@ -213,7 +213,7 @@ public class PersistentExpiringLockManager implements AutoCloseable {
                     } else {
                         processingLockResult = ALREADY_REMOVED;
                     }
-                    applyLockProcessResult(lockId, lockContainer, processingLockResult);
+                    applyProcessingLockResult(lockId, lockContainer, processingLockResult);
                 }
             });
         }
@@ -236,7 +236,7 @@ public class PersistentExpiringLockManager implements AutoCloseable {
             locks.clear();
         }
 
-        private void applyLockProcessResult(
+        private void applyProcessingLockResult(
                 LockIdentity lockId,
                 LockContainer lockContainer,
                 ProcessingLockResult processingLockResult

--- a/jfix-zookeeper/src/main/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainer.kt
+++ b/jfix-zookeeper/src/main/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainer.kt
@@ -67,18 +67,18 @@ class ActiveLocksContainer {
         locks.forEach { (lockId: LockIdentity, lockContainer: LockContainer) ->
             globalLock.lock()
             try {
-                val processingLockResult = if (locks.containsKey(lockId)) {
-                    lockProcessing(lockId, lockContainer.lock, lockContainer.prolongationFailedListener)
-                } else {
-                    ProcessingLockResult.ALREADY_REMOVED
-                }
-                when (processingLockResult) {
-                    ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER -> locks.remove(lockId)
-                    ProcessingLockResult.KEEP_LOCK_IN_CONTAINER -> {
-                        // nothing to do
+                if (locks.containsKey(lockId)) {
+                    val processingLockResult = lockProcessing(
+                            lockId, lockContainer.lock, lockContainer.prolongationFailedListener
+                    )
+                    when (processingLockResult) {
+                        ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER -> locks.remove(lockId)
+                        ProcessingLockResult.KEEP_LOCK_IN_CONTAINER -> {
+                            // nothing to do
+                        }
                     }
-                    ProcessingLockResult.ALREADY_REMOVED ->
-                        logger.trace("Lock with lockId {} already has been removed by other thread", lockId)
+                } else {
+                    logger.trace("Lock with lockId {} already has been removed by other thread", lockId)
                 }
             } finally {
                 globalLock.unlock()
@@ -93,5 +93,5 @@ class ActiveLocksContainer {
 }
 
 enum class ProcessingLockResult {
-    KEEP_LOCK_IN_CONTAINER, REMOVE_LOCK_FROM_CONTAINER, ALREADY_REMOVED
+    KEEP_LOCK_IN_CONTAINER, REMOVE_LOCK_FROM_CONTAINER
 }

--- a/jfix-zookeeper/src/main/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainer.kt
+++ b/jfix-zookeeper/src/main/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainer.kt
@@ -1,0 +1,117 @@
+package ru.fix.zookeeper.lock
+
+import mu.KotlinLogging
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.locks.ReentrantLock
+
+class ActiveLocksContainer : AutoCloseable {
+    companion object {
+        private val logger = KotlinLogging.logger { }
+    }
+
+    /**
+     * remove, prolong and getState operations MUST BE synced under [.globalLock]
+     */
+    private val locks: ConcurrentMap<LockIdentity, LockContainer> = ConcurrentHashMap()
+
+    /**
+     * all operations with accessing to [.locks] has been synced with this object
+     * LockContainer is encapsulated inside this class so for performance issue this lock could be
+     * replaced with syncing via LockContainer
+     */
+    private val globalLock = ReentrantLock(true)
+
+    /**
+     * @return - old value in the map
+     */
+    fun putLock(
+            lockId: LockIdentity,
+            lock: PersistentExpiringDistributedLock,
+            listener: LockProlongationFailedListener
+    ): PersistentExpiringDistributedLock? {
+        val newLockContainer = LockContainer(lock, listener)
+        val oldLockContainer = locks.put(lockId, newLockContainer)
+        return oldLockContainer?.lock
+    }
+
+    fun removeLock(lockId: LockIdentity): PersistentExpiringDistributedLock? {
+        return try {
+            globalLock.lock()
+            locks.remove(lockId)?.lock
+        } finally {
+            globalLock.unlock()
+        }
+    }
+
+    operator fun contains(lockId: LockIdentity): Boolean {
+        return locks.containsKey(lockId)
+    }
+
+    @Throws(Exception::class)
+    fun getLockState(lockId: LockIdentity): PersistentExpiringDistributedLock.State? {
+        return try {
+            globalLock.lock()
+            locks[lockId]?.lock?.state
+        } finally {
+            globalLock.unlock()
+        }
+    }
+
+    /**
+     * @param lockProcessing       - returns what to do with Lock in collection
+     * @param resultPostProcessing - does some work after processing lock and applied action
+     */
+    fun processAllLocks(
+            lockProcessing: (LockIdentity, PersistentExpiringDistributedLock) -> ProcessingLockResult,
+            resultPostProcessing: (LockIdentity, LockProlongationFailedListener, ProcessingLockResult) -> Unit
+    ) {
+        locks.forEach { (lockId: LockIdentity, lockContainer: LockContainer) ->
+            try {
+                globalLock.lock()
+                val processingLockResult = if (locks.containsKey(lockId)) {
+                    lockProcessing(lockId, lockContainer.lock)
+                } else {
+                    ProcessingLockResult.ALREADY_REMOVED
+                }
+                when (processingLockResult) {
+                    ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER -> locks.remove(lockId)
+                    ProcessingLockResult.KEEP_LOCK_IN_CONTAINER -> {
+                        // nothing to do
+                    }
+                    ProcessingLockResult.ALREADY_REMOVED ->
+                        logger.trace("Lock with lockId {} already has been removed by other thread", lockId)
+                }
+                resultPostProcessing(lockId, lockContainer.prolongationFailedListener, processingLockResult)
+            } finally {
+                globalLock.unlock()
+            }
+        }
+    }
+
+    override fun close() {
+        processAllLocks(
+                lockProcessing = { lockId, lock ->
+                    try {
+                        lock.close()
+                    } catch (e: Exception) {
+                        logger.error(e) { "can't close lock with lockId = $lockId in ActiveLockContainer" }
+                    }
+                    ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER
+                },
+                resultPostProcessing = { _, _, _ ->
+                    // nothing to do
+                }
+        )
+        locks.clear()
+    }
+
+    private data class LockContainer(
+            val lock: PersistentExpiringDistributedLock,
+            val prolongationFailedListener: LockProlongationFailedListener
+    )
+}
+
+enum class ProcessingLockResult {
+    KEEP_LOCK_IN_CONTAINER, REMOVE_LOCK_FROM_CONTAINER, ALREADY_REMOVED
+}

--- a/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
+++ b/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
@@ -33,14 +33,14 @@ internal class ActiveLocksContainerTest {
                 lockId
         )
 
-        val containsLockBeforePutting = activeLocksContainer.contains(lockId)
-        val lockOfEmptyContainer = activeLocksContainer.putLock(lockId, lock, LockProlongationFailedListener {})
-        val containsLockAfterPutting = activeLocksContainer.contains(lockId)
-        val gotLockState = activeLocksContainer.getLockState(lockId)
-        val removedLock = activeLocksContainer.removeLock(lockId)
-        val containsLockAfterRemoving = activeLocksContainer.contains(lockId)
-        val gotLockStateAfterRemove = activeLocksContainer.getLockState(lockId)
-        val removeAfterRemoveLock = activeLocksContainer.removeLock(lockId)
+        val containsLockBeforePutting = lockId in activeLocksContainer
+        val lockOfEmptyContainer = activeLocksContainer.put(lockId, lock, LockProlongationFailedListener {})
+        val containsLockAfterPutting = lockId in activeLocksContainer
+        val gotLockState = activeLocksContainer.get(lockId)
+        val removedLock = activeLocksContainer.remove(lockId)
+        val containsLockAfterRemoving = lockId in activeLocksContainer
+        val gotLockStateAfterRemove = activeLocksContainer.get(lockId)
+        val removeAfterRemoveLock = activeLocksContainer.remove(lockId)
 
         containsLockBeforePutting shouldBe false
         lockOfEmptyContainer shouldBe null

--- a/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
+++ b/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
@@ -7,8 +7,14 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import ru.fix.zookeeper.testing.ZKTestingServer
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class ActiveLocksContainerTest {
+    companion object {
+        val lastLockId = AtomicInteger(1)
+    }
 
     private lateinit var zkServer: ZKTestingServer
 
@@ -27,28 +33,48 @@ internal class ActiveLocksContainerTest {
     @Test
     fun `test activeLockContainer put contains get remove getState operations`() {
         val activeLocksContainer = ActiveLocksContainer()
-        val lockId = LockIdentity(ZKPaths.makePath("/locks", 1.toString()), "meta: ${PersistentExpiringLockManagerTest.LOCK_PATH}/id")
-        val lock = PersistentExpiringDistributedLock(
-                zkServer.client,
-                lockId
-        )
+        val lockId = createLockId()
+        val lock = PersistentExpiringDistributedLock(zkServer.client, lockId)
 
-        val containsLockBeforePutting = lockId in activeLocksContainer
-        val lockOfEmptyContainer = activeLocksContainer.put(lockId, lock, LockProlongationFailedListener {})
-        val containsLockAfterPutting = lockId in activeLocksContainer
-        val gotLockState = activeLocksContainer.get(lockId)
+        (lockId in activeLocksContainer) shouldBe false
+        val putValue = activeLocksContainer.put(lockId, lock, LockProlongationFailedListener {})
+        putValue shouldBe null
+        (lockId in activeLocksContainer) shouldBe true
+        val getLock = activeLocksContainer.get(lockId)
+        getLock shouldBe lock
         val removedLock = activeLocksContainer.remove(lockId)
-        val containsLockAfterRemoving = lockId in activeLocksContainer
-        val gotLockStateAfterRemove = activeLocksContainer.get(lockId)
-        val removeAfterRemoveLock = activeLocksContainer.remove(lockId)
-
-        containsLockBeforePutting shouldBe false
-        lockOfEmptyContainer shouldBe null
-        containsLockAfterPutting shouldBe true
-        gotLockState shouldNotBe null
         removedLock shouldBe lock
-        containsLockAfterRemoving shouldBe false
-        gotLockStateAfterRemove shouldBe null
-        removeAfterRemoveLock shouldBe null
+        (lockId in activeLocksContainer) shouldBe false
+        activeLocksContainer.get(lockId) shouldBe null
+        activeLocksContainer.remove(lockId) shouldBe null
     }
+
+    @Test
+    fun `concurrency iterate remove lock`() {
+        val activeLocksContainer = ActiveLocksContainer()
+        val lockId = createLockId()
+        val lock = PersistentExpiringDistributedLock(zkServer.client, lockId)
+        activeLocksContainer.put(lockId, lock, LockProlongationFailedListener {})
+        val states = mutableListOf<PersistentExpiringDistributedLock.State>()
+
+        val executor = Executors.newSingleThreadExecutor()
+        executor.execute {
+            activeLocksContainer.processAllLocks { lockIdentity, lock, _ ->
+                TimeUnit.MILLISECONDS.sleep(100)
+                states.add(lock.state)
+                return@processAllLocks ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER
+            }
+        }
+        TimeUnit.MILLISECONDS.sleep(20)
+        activeLocksContainer.remove(lockId)
+
+        states.isNotEmpty() shouldBe true
+        states.first() shouldNotBe null
+    }
+
+    private fun createLockId() = LockIdentity(ZKPaths.makePath(
+            "/locks", lastLockId.incrementAndGet().toString()),
+            "meta: ${PersistentExpiringLockManagerTest.LOCK_PATH}/id"
+    )
+
 }

--- a/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
+++ b/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
@@ -1,0 +1,54 @@
+package ru.fix.zookeeper.lock
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.apache.curator.utils.ZKPaths
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import ru.fix.zookeeper.testing.ZKTestingServer
+
+internal class ActiveLocksContainerTest {
+
+    private lateinit var zkServer: ZKTestingServer
+
+    @BeforeEach
+    fun setup() {
+        zkServer = ZKTestingServer()
+                .withCloseOnJvmShutdown()
+                .start()
+    }
+
+    @AfterEach
+    fun shutdown() {
+        zkServer.close()
+    }
+
+    @Test
+    fun `test activeLockContainer put contains get remove getState operations`() {
+        val activeLocksContainer = ActiveLocksContainer()
+        val lockId = LockIdentity(ZKPaths.makePath("/locks", 1.toString()), "meta: ${PersistentExpiringLockManagerTest.LOCK_PATH}/id")
+        val lock = PersistentExpiringDistributedLock(
+                zkServer.client,
+                lockId
+        )
+
+        val containsLockBeforePutting = activeLocksContainer.contains(lockId)
+        val lockOfEmptyContainer = activeLocksContainer.putLock(lockId, lock, LockProlongationFailedListener {})
+        val containsLockAfterPutting = activeLocksContainer.contains(lockId)
+        val gotLockState = activeLocksContainer.getLockState(lockId)
+        val removedLock = activeLocksContainer.removeLock(lockId)
+        val containsLockAfterRemoving = activeLocksContainer.contains(lockId)
+        val gotLockStateAfterRemove = activeLocksContainer.getLockState(lockId)
+        val removeAfterRemoveLock = activeLocksContainer.removeLock(lockId)
+
+        containsLockBeforePutting shouldBe false
+        lockOfEmptyContainer shouldBe null
+        containsLockAfterPutting shouldBe true
+        gotLockState shouldNotBe null
+        removedLock shouldBe lock
+        containsLockAfterRemoving shouldBe false
+        gotLockStateAfterRemove shouldBe null
+        removeAfterRemoveLock shouldBe null
+    }
+}

--- a/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
+++ b/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/ActiveLocksContainerTest.kt
@@ -1,5 +1,6 @@
 package ru.fix.zookeeper.lock
 
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.apache.curator.utils.ZKPaths
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import ru.fix.zookeeper.testing.ZKTestingServer
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -55,7 +57,7 @@ internal class ActiveLocksContainerTest {
         val lockId = createLockId()
         val lock = PersistentExpiringDistributedLock(zkServer.client, lockId)
         activeLocksContainer.put(lockId, lock, LockProlongationFailedListener {})
-        val states = mutableListOf<PersistentExpiringDistributedLock.State>()
+        val states = ConcurrentHashMap.newKeySet<PersistentExpiringDistributedLock.State>()
 
         val executor = Executors.newSingleThreadExecutor()
         executor.execute {
@@ -68,7 +70,7 @@ internal class ActiveLocksContainerTest {
         TimeUnit.MILLISECONDS.sleep(20)
         activeLocksContainer.remove(lockId)
 
-        states.isNotEmpty() shouldBe true
+        states.shouldNotBeEmpty()
         states.first() shouldNotBe null
     }
 

--- a/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/PersistentExpiringLockManagerTest.kt
+++ b/jfix-zookeeper/src/test/kotlin/ru/fix/zookeeper/lock/PersistentExpiringLockManagerTest.kt
@@ -371,7 +371,7 @@ internal class PersistentExpiringLockManagerTest {
                 Schedule.withDelay(managerConfig.map { it.lockCheckAndProlongInterval.toMillis() }),
                 0
         ) {
-            locksContainer.processAllLocks({ _, lock ->
+            locksContainer.processAllLocks { _, lock, _ ->
                 var prolonged = false
                 try {
                     latchReleaseOperation.countDown()
@@ -388,10 +388,6 @@ internal class PersistentExpiringLockManagerTest {
                 }
                 if (prolonged) ProcessingLockResult.KEEP_LOCK_IN_CONTAINER
                 else ProcessingLockResult.REMOVE_LOCK_FROM_CONTAINER
-            }) { _, _, lockProcessingResult ->
-                if (lockProcessingResult == ProcessingLockResult.ALREADY_REMOVED) {
-                    prolongExceptions.add(IllegalStateException("Impossible state"))
-                }
             }
         }
         return PersistentExpiringLockManager(


### PR DESCRIPTION
There is a race condition between scheduler thread of `PersistentExpiringLockManager` and outer threads that invoked PersistentExpiringLockManager#release(LockId) method. 
Sequence of events:
0. locks collection contains LOCK01
1. scheduler started iterate collection, get LOCK01
2. outer thread remove, release and close the LOCK01
3. scheduler trying to prolong LOCK01, it has thrown Exception with info about it closing
4. logging the error of lock that already has been deleted with release

![image](https://user-images.githubusercontent.com/2759630/134695490-dd7ebd5c-9e45-4521-afee-f03f7477c0d3.png)

You can reproduce this situation  in revision 8002ace  with failed test ru.fix.zookeeper.lock.PersistentExpiringLockManagerTest#`acquire and release lock`

In this PR catch this situation and add INFO log about it